### PR TITLE
Isolate Chattia concierge cosmetics from functional layers

### DIFF
--- a/chattia/README.md
+++ b/chattia/README.md
@@ -13,6 +13,7 @@ and instrumentation without redeploying the secure automation layers.
 - Real-time UX feedback with a built-in typing indicator, auto-resizing composer, and stateful status messaging.
 - Theme-ready CSS custom properties for accent, focus, glow, and hover treatments with graceful fallbacks.
 - Concierge cosmetics encapsulated inside the interaction window so visual refreshes stay isolated from functional layers.
+- Programmatic update API keeps title, aria labels, placeholder, send label, and accent tokens in sync without touching runtime logic.
 
 ## Quick Start
 1. Host `embed/widget.js` on a static origin (Pages, Netlify, Firebase, etc.).
@@ -77,6 +78,9 @@ code and a body describing the failure.
 - Accent tokens are recalculated through a cosmetic manager that gracefully
   falls back to the last known good palette, ensuring runtime updates cannot
   corrupt the functional pipeline.
+- A `createConciergeShell` builder assembles header, log, status, and composer
+  nodes, exposing update helpers so future visual refreshes can swap cosmetics
+  or copy safely without touching persistence, networking, or security guards.
 
 ## Runtime Flow
 
@@ -88,14 +92,15 @@ Chattia Embed Runtime
 ├── State Management
 │   ├── Session + transcript cache (optional `localStorage`)
 │   └── Busy + typing indicators, ARIA status updates
-├── UI Shell
-│   ├── Interaction window host (`<section class="chattia-shell">`)
-│   ├── Header landmark with dynamic title
-│   ├── Live message log (ARIA `role="log"`)
+├── UI Shell Builder
+│   ├── `createConciergeShell` returns header, log, status, composer references
+│   ├── Header landmark with dynamic title + aria wiring helpers
+│   ├── Live message log (ARIA `role="log"` with scroll isolation)
 │   └── Composer form (textarea, send button, keyboard shortcuts)
 ├── Cosmetic Layer
 │   ├── Inline stylesheet scoped to `.chattia-shell` descendants
-│   └── Accent token manager with update-safe fallbacks
+│   ├── Accent token manager with update-safe fallbacks
+│   └── Programmatic `updateAccent` hook for tenant theming
 └── Network Lifecycle
     ├── Fetch POST to configured endpoint with session headers
     ├── JSON parsing + resilience to malformed payloads

--- a/chattia/README.md
+++ b/chattia/README.md
@@ -7,9 +7,12 @@ and instrumentation without redeploying the secure automation layers.
 
 ## Features
 - Drop-in widget that scans for `[data-chattia-embed]` containers.
-- Configurable accent, title, welcome message, and API endpoint per host page.
-- Session reuse via HTTP-only cookies or custom `sessionId` hand-off.
-- Graceful error handling and accessibility-minded defaults.
+- Configurable accent, title, welcome message, send button label, and API endpoint per host page.
+- Optional persistent transcripts via `data-storage-key`, keeping conversations and session IDs in browser storage.
+- Accessibility-first shell: semantic landmarks, live regions, keyboard submit (Enter) and multiline support (Shift+Enter).
+- Real-time UX feedback with a built-in typing indicator, auto-resizing composer, and stateful status messaging.
+- Theme-ready CSS custom properties for accent, focus, glow, and hover treatments with graceful fallbacks.
+- Concierge cosmetics encapsulated inside the interaction window so visual refreshes stay isolated from functional layers.
 
 ## Quick Start
 1. Host `embed/widget.js` on a static origin (Pages, Netlify, Firebase, etc.).
@@ -22,7 +25,20 @@ and instrumentation without redeploying the secure automation layers.
 
 3. Optionally set `window.CHATTIA_DEFAULT_ENDPOINT` before loading the script to
 define a global default endpoint.
-4. Customize styling by overriding CSS variables or editing the widget source.
+4. Customize styling by overriding CSS variables on `.chattia-shell` or editing the dedicated cosmetic layer in `widget.js`.
+5. (Optional) Provide a `data-storage-key="tenant-123"` attribute to persist the transcript across reloads for that key.
+
+### Supported Data Attributes
+
+| Attribute | Purpose | Example |
+| --- | --- | --- |
+| `data-endpoint` | Overrides the API endpoint used for `fetch` calls. | `https://layer1.example.com/chat` |
+| `data-title` | Sets the header label and ARIA name. | `Concierge` |
+| `data-accent` | Provides an accent color used for buttons, headers, and bubbles. | `#9333ea` |
+| `data-placeholder` | Composer placeholder / input label. | `Type your question…` |
+| `data-welcome` | Prefills an assistant message when no transcript exists. | `Hey there! How can I help?` |
+| `data-send-label` | Localizes the send button text and aria label. | `Submit` |
+| `data-storage-key` | Enables secure local persistence of transcript + sessionId. | `tenant-123` |
 
 ## API Contract
 The widget expects a POST JSON endpoint that returns a JSON payload in the
@@ -45,6 +61,46 @@ code and a body describing the failure.
 - Pair `data-endpoint` with tenant-specific URLs or API keys to segment traffic.
 - Use CSP headers and Subresource Integrity when hosting the script in
   production.
+- When using `data-storage-key`, prefer tenant-specific keys scoped per user to
+  avoid cross-account transcript leakage on shared devices.
+- Consider rotating `sessionId` values server-side when sensitive workflows are
+  completed to reduce replay exposure.
+
+## Concierge Cosmetic Isolation
+
+- The interaction window is mounted as a dedicated `<section class="chattia-shell">`
+  inside your host container so brand updates stay confined to the concierge
+  surface.
+- All cosmetic rules ship via a single inline `<style>` block that only targets
+  `.chattia-shell` descendants, preventing bleed-over into surrounding layout
+  layers.
+- Accent tokens are recalculated through a cosmetic manager that gracefully
+  falls back to the last known good palette, ensuring runtime updates cannot
+  corrupt the functional pipeline.
+
+## Runtime Flow
+
+```
+Chattia Embed Runtime
+├── Configuration Layer
+│   ├── Attribute normalization (`data-*`, global defaults, JS overrides)
+│   └── Accent token derivation for consistent theming
+├── State Management
+│   ├── Session + transcript cache (optional `localStorage`)
+│   └── Busy + typing indicators, ARIA status updates
+├── UI Shell
+│   ├── Interaction window host (`<section class="chattia-shell">`)
+│   ├── Header landmark with dynamic title
+│   ├── Live message log (ARIA `role="log"`)
+│   └── Composer form (textarea, send button, keyboard shortcuts)
+├── Cosmetic Layer
+│   ├── Inline stylesheet scoped to `.chattia-shell` descendants
+│   └── Accent token manager with update-safe fallbacks
+└── Network Lifecycle
+    ├── Fetch POST to configured endpoint with session headers
+    ├── JSON parsing + resilience to malformed payloads
+    └── Result formatting + transcript persistence
+```
 
 ## Local Development
 No bundler is required. Serve `widget.js` locally with any static file server

--- a/chattia/embed/widget.js
+++ b/chattia/embed/widget.js
@@ -87,6 +87,180 @@
     return String(result);
   }
 
+  function createCosmeticLayer(shell, accent) {
+    const style = document.createElement("style");
+    style.textContent = `
+      .chattia-shell { --chattia-accent: #2563eb; --chattia-header-bg: rgba(37,99,235,0.12); --chattia-focus-ring: rgba(37,99,235,0.18); --chattia-glow: rgba(37,99,235,0.45); --chattia-button-hover: rgba(37,99,235,0.35); font-family: "Inter", "Segoe UI", system-ui, sans-serif; border-radius: 20px; overflow: hidden; box-shadow: 0 18px 44px rgba(15,23,42,0.16); background: linear-gradient(180deg, rgba(255,255,255,0.97) 0%, rgba(243,246,255,0.97) 100%); color: #0f172a; display: flex; flex-direction: column; max-width: 420px; min-width: 320px; }
+      .chattia-shell[data-busy="true"] { pointer-events: none; }
+      .chattia-shell__header { padding: 18px 22px; background: var(--chattia-header-bg); display: flex; gap: 10px; align-items: center; text-transform: uppercase; font-size: 12px; letter-spacing: 0.12em; font-weight: 600; }
+      .chattia-shell__header::before { content: ""; width: 10px; height: 10px; border-radius: 999px; background: var(--chattia-accent); box-shadow: 0 0 16px var(--chattia-glow); }
+      .chattia-shell__title { margin: 0; font-size: 12px; letter-spacing: 0.12em; font-weight: 600; }
+      .chattia-shell__messages { padding: 22px; flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 16px; }
+      .chattia-shell__bubble { border-radius: 16px; padding: 12px 16px; font-size: 14px; line-height: 1.55; box-shadow: 0 12px 36px rgba(15,23,42,0.12); }
+      .chattia-shell__bubble--user { align-self: flex-end; background: var(--chattia-accent); color: #fff; }
+      .chattia-shell__bubble--assistant { align-self: flex-start; background: #ffffff; border: 1px solid rgba(15,23,42,0.08); }
+      .chattia-shell__bubble--typing { display: inline-flex; gap: 4px; }
+      .chattia-shell__bubble--typing span { width: 6px; height: 6px; border-radius: 999px; background: rgba(15,23,42,0.28); animation: chattia-pulse 1.2s infinite ease-in-out; }
+      .chattia-shell__bubble--typing span:nth-child(2) { animation-delay: 0.15s; }
+      .chattia-shell__bubble--typing span:nth-child(3) { animation-delay: 0.3s; }
+      .chattia-shell__form { padding: 18px; background: rgba(15,23,42,0.02); display: flex; gap: 10px; align-items: flex-end; }
+      .chattia-shell__input { flex: 1; border-radius: 16px; border: 1px solid rgba(15,23,42,0.12); padding: 12px 18px; font-size: 14px; line-height: 1.5; transition: border 0.2s ease, box-shadow 0.2s ease; resize: none; min-height: 48px; max-height: 200px; }
+      .chattia-shell__input:focus { outline: none; border-color: var(--chattia-accent); box-shadow: 0 0 0 3px var(--chattia-focus-ring); }
+      .chattia-shell__input::placeholder { color: rgba(15,23,42,0.45); }
+      .chattia-shell__button { border-radius: 999px; border: none; background: var(--chattia-accent); color: #fff; font-weight: 600; padding: 12px 26px; cursor: pointer; transition: transform 0.18s ease, box-shadow 0.18s ease; }
+      .chattia-shell__button:disabled { opacity: 0.5; cursor: not-allowed; box-shadow: none; transform: none; }
+      .chattia-shell__button:not(:disabled):hover { transform: translateY(-1px); box-shadow: 0 14px 28px var(--chattia-button-hover); }
+      .chattia-shell__status { padding: 0 18px 14px; font-size: 12px; color: rgba(15,23,42,0.58); min-height: 18px; }
+      .chattia-shell__messages::-webkit-scrollbar { width: 6px; }
+      .chattia-shell__messages::-webkit-scrollbar-thumb { background: rgba(15,23,42,0.18); border-radius: 999px; }
+      @keyframes chattia-pulse { 0%, 80%, 100% { opacity: 0.2; transform: translateY(0); } 40% { opacity: 1; transform: translateY(-3px); } }
+      @media (prefers-reduced-motion: reduce) {
+        .chattia-shell__button:not(:disabled):hover { transform: none; box-shadow: none; }
+        .chattia-shell__bubble--typing span { animation: none; opacity: 0.4; }
+      }
+    `;
+    shell.appendChild(style);
+
+    function applyAccent(nextAccent, tokens) {
+      shell.style.setProperty("--chattia-accent", nextAccent);
+      shell.style.setProperty("--chattia-header-bg", tokens.header);
+      shell.style.setProperty("--chattia-focus-ring", tokens.focus);
+      shell.style.setProperty("--chattia-glow", tokens.glow);
+      shell.style.setProperty("--chattia-button-hover", tokens.hover);
+    }
+
+    let currentTokens = {
+      header: colorWithAlpha(accent, 0.12, "rgba(37,99,235,0.12)"),
+      focus: colorWithAlpha(accent, 0.18, "rgba(37,99,235,0.18)"),
+      glow: colorWithAlpha(accent, 0.45, "rgba(37,99,235,0.45)"),
+      hover: colorWithAlpha(accent, 0.35, "rgba(37,99,235,0.35)"),
+    };
+    applyAccent(accent, currentTokens);
+
+    return {
+      updateAccent(nextAccent) {
+        const nextTokens = {
+          header: colorWithAlpha(nextAccent, 0.12, currentTokens.header),
+          focus: colorWithAlpha(nextAccent, 0.18, currentTokens.focus),
+          glow: colorWithAlpha(nextAccent, 0.45, currentTokens.glow),
+          hover: colorWithAlpha(nextAccent, 0.35, currentTokens.hover),
+        };
+        applyAccent(nextAccent, nextTokens);
+        currentTokens = nextTokens;
+      },
+    };
+  }
+
+  function createHeader(titleText) {
+    const header = document.createElement("header");
+    header.className = "chattia-shell__header";
+    const title = document.createElement("h2");
+    title.className = "chattia-shell__title";
+    title.textContent = titleText;
+    title.setAttribute("role", "heading");
+    title.setAttribute("aria-level", "2");
+    header.appendChild(title);
+
+    return {
+      element: header,
+      setTitle(nextTitle) {
+        title.textContent = nextTitle;
+      },
+    };
+  }
+
+  function createMessageLog(titleText) {
+    const element = document.createElement("div");
+    element.className = "chattia-shell__messages";
+    element.setAttribute("role", "log");
+    element.setAttribute("aria-live", "polite");
+    element.setAttribute("aria-label", `${titleText} conversation transcript`);
+
+    return {
+      element,
+      scrollToBottom() {
+        element.scrollTop = element.scrollHeight;
+      },
+      updateLabel(nextTitle) {
+        element.setAttribute("aria-label", `${nextTitle} conversation transcript`);
+      },
+    };
+  }
+
+  function createStatus() {
+    const element = document.createElement("div");
+    element.className = "chattia-shell__status";
+    element.setAttribute("role", "status");
+    element.setAttribute("aria-live", "polite");
+
+    return {
+      element,
+      set(text) {
+        element.textContent = text;
+      },
+      get() {
+        return element.textContent;
+      },
+    };
+  }
+
+  function createComposer(config) {
+    const form = document.createElement("form");
+    form.className = "chattia-shell__form";
+    form.setAttribute("aria-label", `${config.title} message composer`);
+    form.setAttribute("aria-busy", "false");
+
+    const input = document.createElement("textarea");
+    input.className = "chattia-shell__input";
+    input.placeholder = config.placeholder;
+    input.setAttribute("aria-label", config.placeholder);
+    input.setAttribute("autocomplete", "off");
+    input.setAttribute("rows", "1");
+    input.setAttribute("data-gramm", "false");
+    input.setAttribute("data-lt-active", "false");
+
+    const button = document.createElement("button");
+    button.className = "chattia-shell__button";
+    button.type = "submit";
+    button.textContent = config.sendLabel;
+    button.setAttribute("aria-label", config.sendLabel);
+
+    form.append(input, button);
+
+    return {
+      element: form,
+      input,
+      button,
+      setPlaceholder(placeholder) {
+        input.placeholder = placeholder;
+        input.setAttribute("aria-label", placeholder);
+      },
+      setComposerTitle(title) {
+        form.setAttribute("aria-label", `${title} message composer`);
+      },
+      setSendLabel(label) {
+        button.textContent = label;
+        button.setAttribute("aria-label", label);
+      },
+    };
+  }
+
+  function createConciergeShell(config) {
+    const shell = document.createElement("section");
+    shell.className = "chattia-shell";
+    shell.dataset.busy = "false";
+
+    const cosmetics = createCosmeticLayer(shell, config.accent);
+    const header = createHeader(config.title);
+    const log = createMessageLog(config.title);
+    const status = createStatus();
+    const composer = createComposer(config);
+
+    shell.append(header.element, log.element, status.element, composer.element);
+
+    return { shell, cosmetics, header, log, status, composer };
+  }
+
   function mount(element, options = {}) {
     if (!element) return null;
 
@@ -111,127 +285,19 @@
 
     element.innerHTML = "";
 
-    const shell = document.createElement("section");
-    shell.className = "chattia-shell";
-    shell.dataset.busy = "false";
+    const { shell, cosmetics, header, log, status, composer } = createConciergeShell(config);
     element.appendChild(shell);
 
-    const cosmetics = (() => {
-      const style = document.createElement("style");
-      style.textContent = `
-        .chattia-shell { --chattia-accent: #2563eb; --chattia-header-bg: rgba(37,99,235,0.12); --chattia-focus-ring: rgba(37,99,235,0.18); --chattia-glow: rgba(37,99,235,0.45); --chattia-button-hover: rgba(37,99,235,0.35); font-family: "Inter", "Segoe UI", system-ui, sans-serif; border-radius: 20px; overflow: hidden; box-shadow: 0 18px 44px rgba(15,23,42,0.16); background: linear-gradient(180deg, rgba(255,255,255,0.97) 0%, rgba(243,246,255,0.97) 100%); color: #0f172a; display: flex; flex-direction: column; max-width: 420px; min-width: 320px; }
-        .chattia-shell[data-busy="true"] { pointer-events: none; }
-        .chattia-shell__header { padding: 18px 22px; background: var(--chattia-header-bg); display: flex; gap: 10px; align-items: center; text-transform: uppercase; font-size: 12px; letter-spacing: 0.12em; font-weight: 600; }
-        .chattia-shell__header::before { content: ""; width: 10px; height: 10px; border-radius: 999px; background: var(--chattia-accent); box-shadow: 0 0 16px var(--chattia-glow); }
-        .chattia-shell__title { margin: 0; font-size: 12px; letter-spacing: 0.12em; font-weight: 600; }
-        .chattia-shell__messages { padding: 22px; flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 16px; }
-        .chattia-shell__bubble { border-radius: 16px; padding: 12px 16px; font-size: 14px; line-height: 1.55; box-shadow: 0 12px 36px rgba(15,23,42,0.12); }
-        .chattia-shell__bubble--user { align-self: flex-end; background: var(--chattia-accent); color: #fff; }
-        .chattia-shell__bubble--assistant { align-self: flex-start; background: #ffffff; border: 1px solid rgba(15,23,42,0.08); }
-        .chattia-shell__bubble--typing { display: inline-flex; gap: 4px; }
-        .chattia-shell__bubble--typing span { width: 6px; height: 6px; border-radius: 999px; background: rgba(15,23,42,0.28); animation: chattia-pulse 1.2s infinite ease-in-out; }
-        .chattia-shell__bubble--typing span:nth-child(2) { animation-delay: 0.15s; }
-        .chattia-shell__bubble--typing span:nth-child(3) { animation-delay: 0.3s; }
-        .chattia-shell__form { padding: 18px; background: rgba(15,23,42,0.02); display: flex; gap: 10px; align-items: flex-end; }
-        .chattia-shell__input { flex: 1; border-radius: 16px; border: 1px solid rgba(15,23,42,0.12); padding: 12px 18px; font-size: 14px; line-height: 1.5; transition: border 0.2s ease, box-shadow 0.2s ease; resize: none; min-height: 48px; max-height: 200px; }
-        .chattia-shell__input:focus { outline: none; border-color: var(--chattia-accent); box-shadow: 0 0 0 3px var(--chattia-focus-ring); }
-        .chattia-shell__input::placeholder { color: rgba(15,23,42,0.45); }
-        .chattia-shell__button { border-radius: 999px; border: none; background: var(--chattia-accent); color: #fff; font-weight: 600; padding: 12px 26px; cursor: pointer; transition: transform 0.18s ease, box-shadow 0.18s ease; }
-        .chattia-shell__button:disabled { opacity: 0.5; cursor: not-allowed; box-shadow: none; transform: none; }
-        .chattia-shell__button:not(:disabled):hover { transform: translateY(-1px); box-shadow: 0 14px 28px var(--chattia-button-hover); }
-        .chattia-shell__status { padding: 0 18px 14px; font-size: 12px; color: rgba(15,23,42,0.58); min-height: 18px; }
-        .chattia-shell__messages::-webkit-scrollbar { width: 6px; }
-        .chattia-shell__messages::-webkit-scrollbar-thumb { background: rgba(15,23,42,0.18); border-radius: 999px; }
-        @keyframes chattia-pulse { 0%, 80%, 100% { opacity: 0.2; transform: translateY(0); } 40% { opacity: 1; transform: translateY(-3px); } }
-        @media (prefers-reduced-motion: reduce) {
-          .chattia-shell__button:not(:disabled):hover { transform: none; box-shadow: none; }
-          .chattia-shell__bubble--typing span { animation: none; opacity: 0.4; }
-        }
-      `;
-      shell.appendChild(style);
-
-      function applyAccent(accent, tokens) {
-        shell.style.setProperty("--chattia-accent", accent);
-        shell.style.setProperty("--chattia-header-bg", tokens.header);
-        shell.style.setProperty("--chattia-focus-ring", tokens.focus);
-        shell.style.setProperty("--chattia-glow", tokens.glow);
-        shell.style.setProperty("--chattia-button-hover", tokens.hover);
-      }
-
-      let currentTokens = {
-        header: colorWithAlpha(config.accent, 0.12, "rgba(37,99,235,0.12)"),
-        focus: colorWithAlpha(config.accent, 0.18, "rgba(37,99,235,0.18)"),
-        glow: colorWithAlpha(config.accent, 0.45, "rgba(37,99,235,0.45)"),
-        hover: colorWithAlpha(config.accent, 0.35, "rgba(37,99,235,0.35)"),
-      };
-      applyAccent(config.accent, currentTokens);
-
-      return {
-        updateAccent(accent) {
-          const nextTokens = {
-            header: colorWithAlpha(accent, 0.12, currentTokens.header),
-            focus: colorWithAlpha(accent, 0.18, currentTokens.focus),
-            glow: colorWithAlpha(accent, 0.45, currentTokens.glow),
-            hover: colorWithAlpha(accent, 0.35, currentTokens.hover),
-          };
-          applyAccent(accent, nextTokens);
-          currentTokens = nextTokens;
-        },
-      };
-    })();
-
-    const header = document.createElement("header");
-    header.className = "chattia-shell__header";
-    const title = document.createElement("h2");
-    title.className = "chattia-shell__title";
-    title.textContent = config.title;
-    title.setAttribute("role", "heading");
-    title.setAttribute("aria-level", "2");
-    header.appendChild(title);
-
-    const messages = document.createElement("div");
-    messages.className = "chattia-shell__messages";
-    messages.setAttribute("role", "log");
-    messages.setAttribute("aria-live", "polite");
-    messages.setAttribute("aria-label", `${config.title} conversation transcript`);
-
-    const status = document.createElement("div");
-    status.className = "chattia-shell__status";
-    status.setAttribute("role", "status");
-    status.setAttribute("aria-live", "polite");
-
-    const form = document.createElement("form");
-    form.className = "chattia-shell__form";
-    form.setAttribute("aria-label", `${config.title} message composer`);
-    form.setAttribute("aria-busy", "false");
-
-    const input = document.createElement("textarea");
-    input.className = "chattia-shell__input";
-    input.placeholder = config.placeholder;
-    input.setAttribute("aria-label", config.placeholder);
-    input.setAttribute("autocomplete", "off");
-    input.setAttribute("rows", "1");
-    input.setAttribute("data-gramm", "false");
-    input.setAttribute("data-lt-active", "false");
-
-    const button = document.createElement("button");
-    button.className = "chattia-shell__button";
-    button.type = "submit";
-    button.textContent = config.sendLabel;
-    button.setAttribute("aria-label", config.sendLabel);
-
-    form.append(input, button);
-    shell.append(header, messages, status, form);
-
     function autoResizeTextarea() {
-      input.style.height = "auto";
-      input.style.height = `${Math.min(input.scrollHeight, 200)}px`;
+      const textarea = composer.input;
+      textarea.style.height = "auto";
+      textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`;
     }
 
     function updateBusyState(nextBusy) {
       state.busy = nextBusy;
-      button.disabled = nextBusy;
-      form.setAttribute("aria-busy", String(nextBusy));
+      composer.button.disabled = nextBusy;
+      composer.element.setAttribute("aria-busy", String(nextBusy));
       shell.dataset.busy = String(nextBusy);
     }
 
@@ -251,8 +317,8 @@
 
     function appendBubble(role, text, persist = true) {
       const bubble = createBubble(role, text);
-      messages.appendChild(bubble);
-      messages.scrollTop = messages.scrollHeight;
+      log.element.appendChild(bubble);
+      log.scrollToBottom();
       if (persist) {
         state.messages.push({ role, text });
         saveState();
@@ -265,9 +331,9 @@
         return;
       }
       updateBusyState(true);
-      status.textContent = "Connecting…";
+      status.set("Connecting…");
       appendBubble("user", prompt);
-      input.value = "";
+      composer.input.value = "";
       autoResizeTextarea();
 
       if (state.typingBubble) {
@@ -279,8 +345,8 @@
         const dot = document.createElement("span");
         state.typingBubble.appendChild(dot);
       });
-      messages.appendChild(state.typingBubble);
-      messages.scrollTop = messages.scrollHeight;
+      log.element.appendChild(state.typingBubble);
+      log.scrollToBottom();
 
       try {
         const headers = { "content-type": "application/json" };
@@ -299,10 +365,10 @@
         }
         const message = data && data.result ? formatResult(data.result) : "No response received.";
         appendBubble("assistant", message);
-        status.textContent = response.ok ? "Ready" : "Assistant reported an issue.";
+        status.set(response.ok ? "Ready" : "Assistant reported an issue.");
       } catch (error) {
         appendBubble("assistant", "An error occurred while contacting the assistant.");
-        status.textContent = "Connection error";
+        status.set("Connection error");
         console.error("ChattiaEmbed error", error);
       } finally {
         if (state.typingBubble) {
@@ -314,31 +380,31 @@
       }
     }
 
-    form.addEventListener("submit", (event) => {
+    composer.element.addEventListener("submit", (event) => {
       event.preventDefault();
-      dispatchPrompt(input.value.trim());
+      dispatchPrompt(composer.input.value.trim());
     });
 
-    input.addEventListener("keydown", (event) => {
+    composer.input.addEventListener("keydown", (event) => {
       if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault();
-        dispatchPrompt(input.value.trim());
+        dispatchPrompt(composer.input.value.trim());
       }
     });
 
-    input.addEventListener("input", autoResizeTextarea);
+    composer.input.addEventListener("input", autoResizeTextarea);
     autoResizeTextarea();
 
     if (state.messages.length > 0) {
       state.messages.forEach(({ role, text }) => {
         appendBubble(role, text, false);
       });
-      status.textContent = "Ready";
+      status.set("Ready");
     } else if (config.welcome) {
       appendBubble("assistant", config.welcome);
     }
 
-    status.textContent = status.textContent || "Ready";
+    status.set(status.get() || "Ready");
     saveState();
 
     return {
@@ -349,15 +415,19 @@
       },
       update(updates = {}) {
         if (updates.title) {
-          title.textContent = updates.title;
+          header.setTitle(updates.title);
+          log.updateLabel(updates.title);
+          composer.setComposerTitle(updates.title);
         }
         if (updates.placeholder) {
-          input.placeholder = updates.placeholder;
-          input.setAttribute("aria-label", updates.placeholder);
+          composer.setPlaceholder(updates.placeholder);
         }
         if (updates.accent) {
           const accent = updates.accent;
           cosmetics.updateAccent(accent);
+        }
+        if (updates.sendLabel) {
+          composer.setSendLabel(updates.sendLabel);
         }
       },
     };

--- a/chattia/embed/widget.js
+++ b/chattia/embed/widget.js
@@ -1,6 +1,18 @@
 (() => {
   const DEFAULT_ENDPOINT = window.CHATTIA_DEFAULT_ENDPOINT || "/api/chattia";
 
+  const SUPPORTS_LOCAL_STORAGE = (() => {
+    try {
+      const probeKey = "__chattia_probe__";
+      window.localStorage.setItem(probeKey, "1");
+      window.localStorage.removeItem(probeKey);
+      return true;
+    } catch (error) {
+      console.warn("ChattiaEmbed: localStorage unavailable", error);
+      return false;
+    }
+  })();
+
   function normalizeEndpoint(element, options = {}) {
     const attrEndpoint = element.getAttribute("data-endpoint");
     return options.endpoint || attrEndpoint || DEFAULT_ENDPOINT;
@@ -9,6 +21,57 @@
   function normalize(element, key, options, fallback) {
     const attr = element.getAttribute(`data-${key}`);
     return options[key] || attr || fallback;
+  }
+
+  function colorWithAlpha(color, alpha, fallback) {
+    if (typeof color !== "string") return fallback;
+    const value = color.trim();
+    const hexMatch = value.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+    if (hexMatch) {
+      let hex = hexMatch[1];
+      if (hex.length === 3) {
+        hex = hex
+          .split("")
+          .map((char) => char + char)
+          .join("");
+      }
+      const int = parseInt(hex, 16);
+      const r = (int >> 16) & 255;
+      const g = (int >> 8) & 255;
+      const b = int & 255;
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+    const rgbMatch = value.match(/^rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/i);
+    if (rgbMatch) {
+      const [, r, g, b] = rgbMatch;
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+    const rgbaMatch = value.match(/^rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([0-9.]+)\s*\)$/i);
+    if (rgbaMatch) {
+      const [, r, g, b] = rgbaMatch;
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+    return fallback;
+  }
+
+  function persistState(storageKey, payload) {
+    if (!storageKey || !SUPPORTS_LOCAL_STORAGE) return;
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(payload));
+    } catch (error) {
+      console.warn("ChattiaEmbed: unable to persist state", error);
+    }
+  }
+
+  function readPersistedState(storageKey) {
+    if (!storageKey || !SUPPORTS_LOCAL_STORAGE) return null;
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      return raw ? JSON.parse(raw) : null;
+    } catch (error) {
+      console.warn("ChattiaEmbed: unable to read persisted state", error);
+      return null;
+    }
   }
 
   function formatResult(result) {
@@ -33,80 +96,191 @@
       accent: normalize(element, "accent", options, "#2563eb"),
       placeholder: normalize(element, "placeholder", options, "Ask me anything…"),
       welcome: normalize(element, "welcome", options, "How can I support you today?"),
+      sendLabel: normalize(element, "send-label", options, "Send"),
+      storageKey: normalize(element, "storage-key", options, null),
     };
 
+    const persistedState = readPersistedState(config.storageKey) || {};
+
     const state = {
-      sessionId: options.sessionId || null,
+      sessionId: options.sessionId || persistedState.sessionId || null,
       busy: false,
+      typingBubble: null,
+      messages: Array.isArray(persistedState.messages) ? [...persistedState.messages] : [],
     };
 
     element.innerHTML = "";
-    element.classList.add("chattia-shell");
 
-    const style = document.createElement("style");
-    style.textContent = `
-      .chattia-shell { font-family: "Inter", "Segoe UI", system-ui, sans-serif; border-radius: 20px; overflow: hidden; box-shadow: 0 18px 44px rgba(15,23,42,0.16); background: linear-gradient(180deg, rgba(255,255,255,0.97) 0%, rgba(243,246,255,0.97) 100%); color: #0f172a; display: flex; flex-direction: column; max-width: 420px; min-width: 320px; }
-      .chattia-shell__header { padding: 18px 22px; background: rgba(37,99,235,0.12); display: flex; gap: 10px; align-items: center; text-transform: uppercase; font-size: 12px; letter-spacing: 0.12em; font-weight: 600; }
-      .chattia-shell__header::before { content: ""; width: 10px; height: 10px; border-radius: 999px; background: ${config.accent}; box-shadow: 0 0 16px rgba(37,99,235,0.45); }
-      .chattia-shell__messages { padding: 22px; flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 16px; }
-      .chattia-shell__bubble { border-radius: 16px; padding: 12px 16px; font-size: 14px; line-height: 1.55; box-shadow: 0 12px 36px rgba(15,23,42,0.12); }
-      .chattia-shell__bubble--user { align-self: flex-end; background: ${config.accent}; color: #fff; }
-      .chattia-shell__bubble--assistant { align-self: flex-start; background: #ffffff; border: 1px solid rgba(15,23,42,0.08); }
-      .chattia-shell__form { padding: 18px; background: rgba(15,23,42,0.02); display: flex; gap: 10px; }
-      .chattia-shell__input { flex: 1; border-radius: 999px; border: 1px solid rgba(15,23,42,0.12); padding: 12px 18px; font-size: 14px; transition: border 0.2s ease, box-shadow 0.2s ease; }
-      .chattia-shell__input:focus { outline: none; border-color: ${config.accent}; box-shadow: 0 0 0 3px rgba(37,99,235,0.18); }
-      .chattia-shell__button { border-radius: 999px; border: none; background: ${config.accent}; color: #fff; font-weight: 600; padding: 0 26px; cursor: pointer; transition: transform 0.18s ease, box-shadow 0.18s ease; }
-      .chattia-shell__button:disabled { opacity: 0.5; cursor: not-allowed; box-shadow: none; transform: none; }
-      .chattia-shell__button:not(:disabled):hover { transform: translateY(-1px); box-shadow: 0 14px 28px rgba(37,99,235,0.35); }
-      .chattia-shell__status { padding: 0 18px 14px; font-size: 12px; color: rgba(15,23,42,0.58); min-height: 18px; }
-      .chattia-shell__messages::-webkit-scrollbar { width: 6px; }
-      .chattia-shell__messages::-webkit-scrollbar-thumb { background: rgba(15,23,42,0.18); border-radius: 999px; }
-    `;
-    element.appendChild(style);
+    const shell = document.createElement("section");
+    shell.className = "chattia-shell";
+    shell.dataset.busy = "false";
+    element.appendChild(shell);
 
-    const header = document.createElement("div");
+    const cosmetics = (() => {
+      const style = document.createElement("style");
+      style.textContent = `
+        .chattia-shell { --chattia-accent: #2563eb; --chattia-header-bg: rgba(37,99,235,0.12); --chattia-focus-ring: rgba(37,99,235,0.18); --chattia-glow: rgba(37,99,235,0.45); --chattia-button-hover: rgba(37,99,235,0.35); font-family: "Inter", "Segoe UI", system-ui, sans-serif; border-radius: 20px; overflow: hidden; box-shadow: 0 18px 44px rgba(15,23,42,0.16); background: linear-gradient(180deg, rgba(255,255,255,0.97) 0%, rgba(243,246,255,0.97) 100%); color: #0f172a; display: flex; flex-direction: column; max-width: 420px; min-width: 320px; }
+        .chattia-shell[data-busy="true"] { pointer-events: none; }
+        .chattia-shell__header { padding: 18px 22px; background: var(--chattia-header-bg); display: flex; gap: 10px; align-items: center; text-transform: uppercase; font-size: 12px; letter-spacing: 0.12em; font-weight: 600; }
+        .chattia-shell__header::before { content: ""; width: 10px; height: 10px; border-radius: 999px; background: var(--chattia-accent); box-shadow: 0 0 16px var(--chattia-glow); }
+        .chattia-shell__title { margin: 0; font-size: 12px; letter-spacing: 0.12em; font-weight: 600; }
+        .chattia-shell__messages { padding: 22px; flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 16px; }
+        .chattia-shell__bubble { border-radius: 16px; padding: 12px 16px; font-size: 14px; line-height: 1.55; box-shadow: 0 12px 36px rgba(15,23,42,0.12); }
+        .chattia-shell__bubble--user { align-self: flex-end; background: var(--chattia-accent); color: #fff; }
+        .chattia-shell__bubble--assistant { align-self: flex-start; background: #ffffff; border: 1px solid rgba(15,23,42,0.08); }
+        .chattia-shell__bubble--typing { display: inline-flex; gap: 4px; }
+        .chattia-shell__bubble--typing span { width: 6px; height: 6px; border-radius: 999px; background: rgba(15,23,42,0.28); animation: chattia-pulse 1.2s infinite ease-in-out; }
+        .chattia-shell__bubble--typing span:nth-child(2) { animation-delay: 0.15s; }
+        .chattia-shell__bubble--typing span:nth-child(3) { animation-delay: 0.3s; }
+        .chattia-shell__form { padding: 18px; background: rgba(15,23,42,0.02); display: flex; gap: 10px; align-items: flex-end; }
+        .chattia-shell__input { flex: 1; border-radius: 16px; border: 1px solid rgba(15,23,42,0.12); padding: 12px 18px; font-size: 14px; line-height: 1.5; transition: border 0.2s ease, box-shadow 0.2s ease; resize: none; min-height: 48px; max-height: 200px; }
+        .chattia-shell__input:focus { outline: none; border-color: var(--chattia-accent); box-shadow: 0 0 0 3px var(--chattia-focus-ring); }
+        .chattia-shell__input::placeholder { color: rgba(15,23,42,0.45); }
+        .chattia-shell__button { border-radius: 999px; border: none; background: var(--chattia-accent); color: #fff; font-weight: 600; padding: 12px 26px; cursor: pointer; transition: transform 0.18s ease, box-shadow 0.18s ease; }
+        .chattia-shell__button:disabled { opacity: 0.5; cursor: not-allowed; box-shadow: none; transform: none; }
+        .chattia-shell__button:not(:disabled):hover { transform: translateY(-1px); box-shadow: 0 14px 28px var(--chattia-button-hover); }
+        .chattia-shell__status { padding: 0 18px 14px; font-size: 12px; color: rgba(15,23,42,0.58); min-height: 18px; }
+        .chattia-shell__messages::-webkit-scrollbar { width: 6px; }
+        .chattia-shell__messages::-webkit-scrollbar-thumb { background: rgba(15,23,42,0.18); border-radius: 999px; }
+        @keyframes chattia-pulse { 0%, 80%, 100% { opacity: 0.2; transform: translateY(0); } 40% { opacity: 1; transform: translateY(-3px); } }
+        @media (prefers-reduced-motion: reduce) {
+          .chattia-shell__button:not(:disabled):hover { transform: none; box-shadow: none; }
+          .chattia-shell__bubble--typing span { animation: none; opacity: 0.4; }
+        }
+      `;
+      shell.appendChild(style);
+
+      function applyAccent(accent, tokens) {
+        shell.style.setProperty("--chattia-accent", accent);
+        shell.style.setProperty("--chattia-header-bg", tokens.header);
+        shell.style.setProperty("--chattia-focus-ring", tokens.focus);
+        shell.style.setProperty("--chattia-glow", tokens.glow);
+        shell.style.setProperty("--chattia-button-hover", tokens.hover);
+      }
+
+      let currentTokens = {
+        header: colorWithAlpha(config.accent, 0.12, "rgba(37,99,235,0.12)"),
+        focus: colorWithAlpha(config.accent, 0.18, "rgba(37,99,235,0.18)"),
+        glow: colorWithAlpha(config.accent, 0.45, "rgba(37,99,235,0.45)"),
+        hover: colorWithAlpha(config.accent, 0.35, "rgba(37,99,235,0.35)"),
+      };
+      applyAccent(config.accent, currentTokens);
+
+      return {
+        updateAccent(accent) {
+          const nextTokens = {
+            header: colorWithAlpha(accent, 0.12, currentTokens.header),
+            focus: colorWithAlpha(accent, 0.18, currentTokens.focus),
+            glow: colorWithAlpha(accent, 0.45, currentTokens.glow),
+            hover: colorWithAlpha(accent, 0.35, currentTokens.hover),
+          };
+          applyAccent(accent, nextTokens);
+          currentTokens = nextTokens;
+        },
+      };
+    })();
+
+    const header = document.createElement("header");
     header.className = "chattia-shell__header";
-    header.textContent = config.title;
+    const title = document.createElement("h2");
+    title.className = "chattia-shell__title";
+    title.textContent = config.title;
+    title.setAttribute("role", "heading");
+    title.setAttribute("aria-level", "2");
+    header.appendChild(title);
 
     const messages = document.createElement("div");
     messages.className = "chattia-shell__messages";
+    messages.setAttribute("role", "log");
+    messages.setAttribute("aria-live", "polite");
+    messages.setAttribute("aria-label", `${config.title} conversation transcript`);
 
     const status = document.createElement("div");
     status.className = "chattia-shell__status";
+    status.setAttribute("role", "status");
+    status.setAttribute("aria-live", "polite");
 
     const form = document.createElement("form");
     form.className = "chattia-shell__form";
+    form.setAttribute("aria-label", `${config.title} message composer`);
+    form.setAttribute("aria-busy", "false");
 
-    const input = document.createElement("input");
+    const input = document.createElement("textarea");
     input.className = "chattia-shell__input";
     input.placeholder = config.placeholder;
-    input.autocomplete = "off";
+    input.setAttribute("aria-label", config.placeholder);
+    input.setAttribute("autocomplete", "off");
+    input.setAttribute("rows", "1");
+    input.setAttribute("data-gramm", "false");
+    input.setAttribute("data-lt-active", "false");
 
     const button = document.createElement("button");
     button.className = "chattia-shell__button";
     button.type = "submit";
-    button.textContent = "Send";
+    button.textContent = config.sendLabel;
+    button.setAttribute("aria-label", config.sendLabel);
 
     form.append(input, button);
-    element.append(header, messages, status, form);
+    shell.append(header, messages, status, form);
 
-    function appendBubble(role, text) {
+    function autoResizeTextarea() {
+      input.style.height = "auto";
+      input.style.height = `${Math.min(input.scrollHeight, 200)}px`;
+    }
+
+    function updateBusyState(nextBusy) {
+      state.busy = nextBusy;
+      button.disabled = nextBusy;
+      form.setAttribute("aria-busy", String(nextBusy));
+      shell.dataset.busy = String(nextBusy);
+    }
+
+    function saveState() {
+      persistState(config.storageKey, {
+        sessionId: state.sessionId,
+        messages: state.messages,
+      });
+    }
+
+    function createBubble(role, text) {
       const bubble = document.createElement("div");
       bubble.className = `chattia-shell__bubble chattia-shell__bubble--${role}`;
       bubble.textContent = text;
+      return bubble;
+    }
+
+    function appendBubble(role, text, persist = true) {
+      const bubble = createBubble(role, text);
       messages.appendChild(bubble);
       messages.scrollTop = messages.scrollHeight;
+      if (persist) {
+        state.messages.push({ role, text });
+        saveState();
+      }
+      return bubble;
     }
 
     async function dispatchPrompt(prompt) {
       if (!prompt || state.busy) {
         return;
       }
-      state.busy = true;
-      button.disabled = true;
+      updateBusyState(true);
       status.textContent = "Connecting…";
       appendBubble("user", prompt);
       input.value = "";
+      autoResizeTextarea();
+
+      if (state.typingBubble) {
+        state.typingBubble.remove();
+      }
+      state.typingBubble = createBubble("assistant", "");
+      state.typingBubble.classList.add("chattia-shell__bubble--typing");
+      [1, 2, 3].forEach(() => {
+        const dot = document.createElement("span");
+        state.typingBubble.appendChild(dot);
+      });
+      messages.appendChild(state.typingBubble);
+      messages.scrollTop = messages.scrollHeight;
 
       try {
         const headers = { "content-type": "application/json" };
@@ -131,8 +305,12 @@
         status.textContent = "Connection error";
         console.error("ChattiaEmbed error", error);
       } finally {
-        state.busy = false;
-        button.disabled = false;
+        if (state.typingBubble) {
+          state.typingBubble.remove();
+          state.typingBubble = null;
+        }
+        saveState();
+        updateBusyState(false);
       }
     }
 
@@ -141,23 +319,45 @@
       dispatchPrompt(input.value.trim());
     });
 
-    if (config.welcome) {
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        dispatchPrompt(input.value.trim());
+      }
+    });
+
+    input.addEventListener("input", autoResizeTextarea);
+    autoResizeTextarea();
+
+    if (state.messages.length > 0) {
+      state.messages.forEach(({ role, text }) => {
+        appendBubble(role, text, false);
+      });
+      status.textContent = "Ready";
+    } else if (config.welcome) {
       appendBubble("assistant", config.welcome);
     }
 
-    status.textContent = "Ready";
+    status.textContent = status.textContent || "Ready";
+    saveState();
 
     return {
       element,
+      shell,
       send(prompt) {
         dispatchPrompt(prompt);
       },
       update(updates = {}) {
         if (updates.title) {
-          header.textContent = updates.title;
+          title.textContent = updates.title;
         }
         if (updates.placeholder) {
           input.placeholder = updates.placeholder;
+          input.setAttribute("aria-label", updates.placeholder);
+        }
+        if (updates.accent) {
+          const accent = updates.accent;
+          cosmetics.updateAccent(accent);
         }
       },
     };


### PR DESCRIPTION
## Summary
- wrap the concierge interaction window in an internal `.chattia-shell` section with a cosmetic manager so visual tweaks stay isolated from runtime logic
- update the documentation to explain the cosmetic layer boundaries and how to target the new shell for theming

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e8f7fa63b4832bb2b2cf95d51d30a2