### PR TITLE
Add repository assessment overview document

### DIFF
--- a/docs/repo-assessment.md
+++ b/docs/repo-assessment.md
@@ -1,0 +1,35 @@
+# Repository Deep Dive
+
+## Monorepo Overview
+This repository aggregates production-ready conversational AI applications alongside security-first Cloudflare Worker meshes and compliance collateral.
+
+| Area | Description | Observations |
+| --- | --- | --- |
+| `apps/LibreChat` | Full LibreChat mono-repo with API, client, and internal packages. | Extensive npm/bun scripts cover backend, frontend, migrations, and Playwright-based QA, signalling an upstream-synced release (`v0.8.0`).【F:apps/LibreChat/package.json†L1-L155】 |
+| `apps/agents-starter` | Cloudflare Agent Starter kit bundled with node_modules. | Vite/Vitest/Workers toolchain is configured; Vitest runs to completion locally (no suites yet).【F:apps/agents-starter/package.json†L1-L60】【a4a38c†L1-L6】 |
+| `chattia` | Embeddable concierge widget for tenant portals. | README plus unbundled JS deliver a configurable, accessibility-aware chat shell with persistent storage hooks.【F:chattia/README.md†L1-L111】【F:chattia/embed/widget.js†L1-L200】 |
+| `worker/edge-mesh` | Seven-layer Cloudflare Worker implementation with shared crypto utilities. | Layered services exchange HMAC-signed payloads, perform heuristic firewalling, BM25 scoring, TinyLLM proxying, orchestration fan-out, and audit logging.【F:worker/edge-mesh/workers/shared/protocol.ts†L1-L94】【F:worker/edge-mesh/workers/layer1-ui/src/index.ts†L1-L137】【F:worker/edge-mesh/workers/layer2-firewall/src/index.ts†L1-L85】【F:worker/edge-mesh/workers/layer4-tiny-ml/src/index.ts†L1-L67】【F:worker/edge-mesh/workers/layer5-tiny-llm/src/index.ts†L1-L48】【F:worker/edge-mesh/workers/layer6-orchestrator/src/index.ts†L1-L95】【F:worker/edge-mesh/workers/layer7-backbone/src/index.ts†L1-L52】 |
+| `ultimate-chatbot` | Strategic blueprint for the same seven layers. | Documentation and stub workers outline responsibilities and policies but stop short of the signed-request mesh shipped under `worker/edge-mesh`.【F:ultimate-chatbot/README.md†L1-L135】【F:ultimate-chatbot/infrastructure/cloudflare/workers/layer1-ui/src/index.ts†L1-L61】 |
+| Compliance & Ops | Cloudflare wrangler config, Zero-Trust policies, CI notes. | Wrangler environments enumerate per-layer deployments but require user-supplied bindings and secrets; CI doc records prior submodule checkout fixes.【F:worker/edge-mesh/wrangler.toml†L1-L62】【F:docs/ci/checkout-troubleshooting.md†L1-L13】 |
+
+## What Is Working Well
+- **Production conversation stacks are vendored** – LibreChat, vLLM, Thorium, and Ollama source trees are present intact, providing proven UI, inference, and analysis capabilities to plug into the layered mesh.【F:apps/LibreChat/package.json†L1-L155】【F:apps/vllm/README.md†L1-L120】【F:apps/thorium-eter/README.md†L1-L24】【F:apps/ollama/README.md†L1-L20】
+- **Edge mesh security model is implemented** – Workers sign and verify every inter-layer request with SHA-256 HMAC, enforce origin allow-lists, redact sensitive headers, and persist sessions in KV, matching the compliance goals stated in the blueprint.【F:worker/edge-mesh/workers/shared/protocol.ts†L1-L94】【F:worker/edge-mesh/workers/layer1-ui/src/index.ts†L11-L125】【F:worker/edge-mesh/workers/layer2-firewall/src/index.ts†L23-L85】
+- **Core orchestration flows function** – The orchestrator concurrently fans out to TinyML and TinyLLM layers, optionally queues Thorium scans, and forwards auditable summaries to the backbone layer, demonstrating an end-to-end service chain when bindings are configured.【F:worker/edge-mesh/workers/layer6-orchestrator/src/index.ts†L22-L95】【F:worker/edge-mesh/workers/layer7-backbone/src/index.ts†L24-L50】
+- **Chattia widget ready for embedding** – The unbundled widget automatically mounts UI shells, manages localStorage transcripts, formats responses, and exposes accent-theming hooks, allowing rapid tenant onboarding without extra build tooling.【F:chattia/embed/widget.js†L1-L200】
+- **Agent starter toolchain installs cleanly** – Vitest executes (albeit with zero suites today), confirming the project bootstraps correctly inside the repo and is ready for bespoke tests.【a4a38c†L1-L6】
+
+## Gaps & Not-Yet-Working Areas
+- **Blueprint workers remain placeholders** – The `ultimate-chatbot` worker stubs simply echo payloads and do not yet participate in the signed-request mesh, so they cannot be deployed without porting the hardened implementations from `worker/edge-mesh`.【F:ultimate-chatbot/infrastructure/cloudflare/workers/layer1-ui/src/index.ts†L8-L36】
+- **Service bindings and storage IDs are unset** – `wrangler.toml` ships blank KV namespace IDs and commented service bindings; deployments will fail until operators supply actual namespace IDs, service binding names, and secrets (e.g., `HMAC_SECRET`, TinyLLM credentials).【F:worker/edge-mesh/wrangler.toml†L11-L62】【F:worker/edge-mesh/workers/layer5-tiny-llm/src/index.ts†L3-L47】
+- **Inference and search layers are demos** – Layer 4 ships a fixed three-document corpus, and Layer 5 proxies to an external TinyLLM endpoint; both require production data stores or Workers AI bindings before yielding useful answers.【F:worker/edge-mesh/workers/layer4-tiny-ml/src/index.ts†L15-L41】【F:worker/edge-mesh/workers/layer5-tiny-llm/src/index.ts†L26-L45】
+- **CI tooling still needs tuning** – Running `npm run check` in `apps/agents-starter` hung on repository-wide Prettier/BIOME scans, signalling commands may need path scopes for this monorepo; execution was cancelled after 20s.【79868e†L1-L20】
+- **Root worker entrypoint is still a placeholder** – `worker/edge-mesh/src/index.ts` only returns a static message, so any traffic hitting the base service requires routing updates to meaningful layer handlers.【F:worker/edge-mesh/src/index.ts†L1-L7】
+- **Prior submodule issue resolved but worth monitoring** – CI documentation shows a previous checkout failure caused by a stale `.gitmodules`. While fixed, any reintroduction of nested submodules should ensure matching root entries.【F:docs/ci/checkout-troubleshooting.md†L1-L13】
+
+## Recommended Next Steps
+1. Port the hardened signed-request handlers from `worker/edge-mesh` into the `ultimate-chatbot` blueprint to keep documentation and deployable code in sync.
+2. Provision Cloudflare KV namespaces, service bindings, and secret values, then update `wrangler.toml` so each environment can be deployed without manual edits.
+3. Swap the demo TinyML corpus for production search infrastructure (Workers AI Vectorize, Durable Object indexes) and confirm TinyLLM credentials or Workers AI models are available.
+4. Scope lint/format commands per package (e.g., `prettier "src/**/*"`) to avoid monorepo-wide scans that stall CI pipelines.
+5. Replace the root mesh placeholder with routing or documentation that clarifies how external requests should target individual layer services.


### PR DESCRIPTION
## Summary
- add a repository assessment document that inventories each major app, worker mesh, and compliance asset
- document working capabilities (LibreChat stack, signed-request worker mesh, Chattia widget) and highlight outstanding gaps or placeholders
- record recommended next steps for wiring Cloudflare bindings and production data sources

## Testing
- npm test -- --run (apps/agents-starter)


------
https://chatgpt.com/codex/tasks/task_e_68e91b28db34832ba6d99355176c2a1d